### PR TITLE
pickAColor erroneously made color tuple of strings; should be ints

### DIFF
--- a/jes4py/PixelColor.py
+++ b/jes4py/PixelColor.py
@@ -571,5 +571,5 @@ class Color:
         if color == '':
             color = None
         else:
-            color = Color(color.split())
+            color = Color(list(map(int,color.split())))
         return color


### PR DESCRIPTION
Previous work to fix pickAColor() introduced a bug where color values were stored as strings not ints.  this PR fixes that problem.