### PR TITLE
Convert colormapped images to RGB when loading them

### DIFF
--- a/jes4py/Picture.py
+++ b/jes4py/Picture.py
@@ -644,6 +644,9 @@ class Picture:
             the name of the file to load the picture from
         """
         self.image = PIL.Image.open(fileName) #.convert('RGB')
+        # convert colormapped image to RGB
+        if self.image.getpalette() is not None:
+            self.image = self.image.convert("RGB")
         self.filename = self.title = fileName
 
 


### PR DESCRIPTION
PIL.open() preserves image format but JES assumes all images are in RGB (or RGBA) format.  To address this we now check if an image has a palette (colormap) associated with it and, if so, convert it to RGB format.