### PR TITLE
Modify show function to work on windows system

### DIFF
--- a/jes4py/show.py
+++ b/jes4py/show.py
@@ -141,7 +141,7 @@ class MainWindow(wx.Frame):
         """
         image = picture.getWxImage()
         imageSize = image.GetSize()
-        bmp = wx.Bitmap(image, wx.BITMAP_TYPE_ANY)
+        bmp = wx.Bitmap(image)
         self.SetTitle(picture.getTitle())
         self.bitmap = wx.StaticBitmap(parent=self.panel, size=imageSize, \
                                         bitmap=bmp)


### PR DESCRIPTION
When creating its wx.Bitmap object, the explore() implementation only passes in the wx.Image object, whereas the show() implementation passes in both the wx.Image object along with a constant wx.BITMAP_TYPE_ANY. Instead of passing in this constant during instantiation of its bitmap object, explore() passes this constant into the creation of its image object. This change simply removes that constant from the bitmap object creation in the show() file.
Some tests across Linux, Mac, Win10, and Win11 suggest that this change offers no additional drawbacks on the systems which already worked with the show function (Mac and Linux), and it does offers sufficient functionality for students using Windows computers to complete the baseline Forest Fire Simulation project. 